### PR TITLE
minimize register reads during firmware transfer

### DIFF
--- a/wfx_fmac_driver/sl_wfx.c
+++ b/wfx_fmac_driver/sl_wfx.c
@@ -2107,28 +2107,27 @@ static sl_status_t sl_wfx_download_run_firmware(void)
 
   /* Firmware downloading loop */
   for ( block = 0; block < num_blocks; block++ ) {
-    /* check the download status in NCP */
-    status = sl_wfx_apb_read_32(ADDR_DWL_CTRL_AREA_NCP_STATUS, &value32);
-    SL_WFX_ERROR_CHECK(status);
-
-    if (value32 != NCP_STATE_DOWNLOAD_PENDING) {
-      status = SL_STATUS_FAIL;
-      SL_WFX_ERROR_CHECK(status);
-    }
-
     /* loop until put - get <= 24K */
     for ( i = 0; i < 100; i++ ) {
-      get = 0;
-      status = sl_wfx_apb_read_32(ADDR_DWL_CTRL_AREA_GET, &get);
-      SL_WFX_ERROR_CHECK(status);
-
       if ((put - get) <= (DOWNLOAD_FIFO_SIZE - DOWNLOAD_BLOCK_SIZE)) {
         break;
       }
+
+      get = 0;
+      status = sl_wfx_apb_read_32(ADDR_DWL_CTRL_AREA_GET, &get);
+      SL_WFX_ERROR_CHECK(status);
     }
 
     if ((put - get) > (DOWNLOAD_FIFO_SIZE - DOWNLOAD_BLOCK_SIZE)) {
-      status = SL_STATUS_WIFI_FIRMWARE_DOWNLOAD_TIMEOUT;
+      /* check the download status in NCP */
+      status = sl_wfx_apb_read_32(ADDR_DWL_CTRL_AREA_NCP_STATUS, &value32);
+      SL_WFX_ERROR_CHECK(status);
+
+      if (value32 != NCP_STATE_DOWNLOAD_PENDING) {
+        status = SL_STATUS_FAIL;
+      } else {
+        status = SL_STATUS_WIFI_FIRMWARE_DOWNLOAD_TIMEOUT;
+      }
       SL_WFX_ERROR_CHECK(status);
     }
 


### PR DESCRIPTION
- Don't bother updating the 'get' variable if the last known value
  already allows for starting the next block.
- Don't check NCP status unless a timeout happens.

These two small changes result in a 76% reduction of the number of
register accesses per loop iteration (from 13 to 3.17) or a 70%
reduction of the total number of cmd53 sdio transfers.  This roughly
halves the time needed to transfer the firmware, which itself is the
dominant part of the wf200 initialization time.

Reduction in firmware download time measured on WGM160P:
- bare_metal example: 88 ms -> 48 ms
- micriumos example: 619 ms -> 207 ms