### PR TITLE
Avoid using sl_wfx_context before it is initialized

### DIFF
--- a/wfx_fmac_driver/sl_wfx.c
+++ b/wfx_fmac_driver/sl_wfx.c
@@ -91,7 +91,7 @@ sl_status_t sl_wfx_init(sl_wfx_context_t *context)
   const char           *pds_data;
 #ifdef SL_WFX_USE_SECURE_LINK
   sl_wfx_secure_link_mode_t link_mode;
-  sl_wfx_context->secure_link_renegotiation_state = SL_WFX_SECURELINK_DEFAULT;
+  context->secure_link_renegotiation_state = SL_WFX_SECURELINK_DEFAULT;
 #endif
 
   memset(context, 0, sizeof(*context) );


### PR DESCRIPTION
In `sl_wfx_init` when `SL_WFX_USE_SECURE_LINK` is defined, `sl_wfx_context` is dereferenced before it is initialized. This patch changes the code to use the `context` parameter, but the line of code could also just be removed as `SL_WFX_SECURELINK_DEFAULT` is 0, and the entire context is memset to 0.
