### PR TITLE
use "firmware/" prefix when including firmware/*.h

### DIFF
--- a/wfx_fmac_driver/bus/sl_wfx_bus_spi.c
+++ b/wfx_fmac_driver/bus/sl_wfx_bus_spi.c
@@ -16,7 +16,7 @@
 
 #include "sl_wfx_bus.h"
 #include "sl_wfx_host_api.h"
-#include "sl_wfx_registers.h"
+#include "firmware/sl_wfx_registers.h"
 
 #define SET_WRITE 0x7FFF /* usage: and operation */
 #define SET_READ 0x8000  /* usage: or operation */

--- a/wfx_fmac_driver/sl_wfx.h
+++ b/wfx_fmac_driver/sl_wfx.h
@@ -21,7 +21,7 @@
 #include "sl_wfx_host_api.h"
 #include "sl_wfx_version.h"
 #include "bus/sl_wfx_bus.h"
-#include "sl_wfx_registers.h"
+#include "firmware/sl_wfx_registers.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/wfx_fmac_driver/sl_wfx_constants.h
+++ b/wfx_fmac_driver/sl_wfx_constants.h
@@ -19,7 +19,7 @@
 
 #include "sl_wfx_configuration_defaults.h"
 #include "sl_status.h"
-#include "sl_wfx_api.h"
+#include "firmware/sl_wfx_api.h"
 #include <stdint.h>
 
 /******************************************************

--- a/wfx_fmac_driver/sl_wfx_host_api.h
+++ b/wfx_fmac_driver/sl_wfx_host_api.h
@@ -17,7 +17,7 @@
 #ifndef SL_WFX_HOST_API_H
 #define SL_WFX_HOST_API_H
 
-#include "sl_wfx_api.h"
+#include "firmware/sl_wfx_api.h"
 #include "sl_wfx_constants.h"
 
 /******************************************************


### PR DESCRIPTION
Perhaps this change may not be generally a good idea across different build environments, but it seems to solve my problem with including `wfx_fmac_driver` as a library in the Arduino IDE.

The problem is that some of the files in `wfx_fmac_driver` and `wfx_fmac_driver/bus` include header files from `wfx_fmac_driver/firmware` without specifying the `firmware/` path prefix in `#include "..."`.

As a consequence, the compiler needs to use an include search path with both `wfx_fmac_driver` and `wfx_fmac_driver/firmware` in order to locate all the necessary header files. As best I can tell, the Arduino IDE currently assumes that each library will only need one directory for its include search path.

For example, a library that needed the equivalent of this would work okay:
   `gcc ... -I wfx_fmac_driver ...`
But, the Arduino IDE apparently cannot cope with a situation that needs something like this:
   `gcc ... -I wfx_fmac_driver -I wfx_fmac_driver/firmware ...`

This pull request attempts to solve the problem by making the following replacements:
- `#include "sl_wfx_registers.h"` becomes `#include "firmware/sl_wfx_registers.h"`
- `#include "sl_wfx_api.h"` becomes `#include "firmware/sl_wfx_api.h"`

For context on manually installing Arduino IDE libraries, see https://www.arduino.cc/en/Guide/Libraries#manual-installation. Please feel free to close this PR if it seems like a bad idea.